### PR TITLE
CSV出力オプション追加、リモート/Docker対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+data/**
+!data/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__/
 .idea/
 data/**
 !data/.gitkeep

--- a/README.md
+++ b/README.md
@@ -33,9 +33,21 @@ data_managerでAPIを利用しjsonを手元に落として、pandas化
 ```
 python data_manager.py --follower_update --list_update --list_user_update --df_update --user_json_update=1
 ```
+
+Excel等の他のアプリで読みたい場合はCSVファイルを出力
+```
+python data_manager.py --output_csv
+```
+
 Flask Appを立ててフォロワー管理
 ```
 python app.py
+```
+
+リモートマシンやDockerコンテナ内で動かす時には、ホストIPアドレスを `0.0.0.0` にしておけばアクセスできる
+（デフォルトの`127.0.0.1`だと外部のクライアントからアクセスできない）
+```
+python app.py --host 0.0.0.0 
 ```
 
 # data manager args

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from data_manager import DataManager
 from utils import get_users, reconv_list
 import json
 import os
+import argparse
 import sys
 app = Flask(__name__)
 
@@ -79,7 +80,13 @@ def follow():
 
 if __name__ == "__main__":
     try:
-        app.run(debug=True)
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--host', default=None, type=str)
+        parser.add_argument('--port', default=None, type=str)
+        parser.add_argument('--debug', default=True, type=bool)
+        args = parser.parse_args()
+        print(args)
+        app.run(debug=args.debug, host=args.host, port=args.port)
     except KeyboardInterrupt:
         dm.save()
     except Exception:

--- a/data_manager.py
+++ b/data_manager.py
@@ -321,8 +321,13 @@ if __name__ == '__main__':
     parser.add_argument('--list_user_update', action='store_true')
     parser.add_argument('--df_update', action='store_true')
     parser.add_argument('--user_json_update', default=0, type=int)
+    parser.add_argument('--output_csv', action='store_true')
     args = parser.parse_args()
     print(args)
     print('data making')
     DM = DataManager(my_id, config, args.follower_update, args.user_json_update, args.df_update, args.list_update, args.list_user_update)
+    if args.output_csv:
+        with open(os.path.join(DM.data_path, 'twdata.pkl'), 'rb') as f:
+            df = pickle.load(f)
+            df.to_csv(os.path.join(DM.data_path, 'twdata.csv'), index=False)
     print('data managed')


### PR DESCRIPTION
Excel等の他のアプリで読めるように、CSV出力オプションを追加しました。

```
python data_manager.py --output_csv
```

リモートマシンやDockerコンテナでFlaskアプリを動かせるようにしました。（デフォルトの挙動は変更無し）
```
python app.py --host 0.0.0.0 
```