### PR TITLE
Avoid breaking change of Tweepy v4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tweepy
+tweepy<4.0.0
 tqdm
 pandas
 feather-format


### PR DESCRIPTION
Running `python data_manager.py --follower_update --list_update --list_user_update --df_update --user_json_update=1` returns `
AttributeError: 'API' object has no attribute 'followers_ids'` if Tweepy v4 is installed.

The apparent cause is that [Tweepy v4.0.0](https://github.com/tweepy/tweepy/releases/tag/v4.0.0) renamed API.followers_ids to [API.get_follower_ids](https://tweepy.readthedocs.io/en/v4.1.0/api.html#tweepy.API.get_follower_ids).

Referene:
https://stackoverflow.com/questions/69751853/attributeerror-api-object-has-no-attribute-followers-ids

This pull request fixes this issue by avoiding Tweepy 4.